### PR TITLE
Updating category summary with tree view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1257,8 +1257,14 @@ impl App {
     // Helper to get visible hierarchical items for the category summary view
     pub(crate) fn get_visible_category_summary_items(&self) -> Vec<CategorySummaryItem> {
         let mut items = Vec::new();
-        if let Some(year) = self.category_summary_years.get(self.category_summary_year_index).copied() {
-            let mut months: Vec<u32> = self.category_summaries.keys()
+        if let Some(year) = self
+            .category_summary_years
+            .get(self.category_summary_year_index)
+            .copied()
+        {
+            let mut months: Vec<u32> = self
+                .category_summaries
+                .keys()
                 .filter_map(|(y, m)| if *y == year { Some(*m) } else { None })
                 .collect();
             months.sort_unstable();
@@ -1272,17 +1278,32 @@ impl App {
                     }
                     items.push(CategorySummaryItem::Month(month, month_total));
                     if self.expanded_category_summary_months.contains(&month) {
-                        let mut categories: Vec<String> = month_map.keys().map(|(cat, _)| cat.clone()).collect();
+                        let mut categories: Vec<String> =
+                            month_map.keys().map(|(cat, _)| cat.clone()).collect();
                         categories.sort_unstable();
                         categories.dedup();
                         for category in categories {
-                            let mut subcategories: Vec<String> = month_map.keys()
-                                .filter_map(|(cat, sub)| if cat == &category && !sub.is_empty() { Some(sub.clone()) } else { None })
+                            let mut subcategories: Vec<String> = month_map
+                                .keys()
+                                .filter_map(|(cat, sub)| {
+                                    if cat == &category && !sub.is_empty() {
+                                        Some(sub.clone())
+                                    } else {
+                                        None
+                                    }
+                                })
                                 .collect();
                             subcategories.sort_unstable();
                             for subcategory in subcategories {
-                                if let Some(summary) = month_map.get(&(category.clone(), subcategory.clone())) {
-                                    items.push(CategorySummaryItem::Subcategory(month, category.clone(), subcategory.clone(), *summary));
+                                if let Some(summary) =
+                                    month_map.get(&(category.clone(), subcategory.clone()))
+                                {
+                                    items.push(CategorySummaryItem::Subcategory(
+                                        month,
+                                        category.clone(),
+                                        subcategory.clone(),
+                                        *summary,
+                                    ));
                                 }
                             }
                         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -659,6 +659,7 @@ impl App {
         }
 
         self.calculate_category_summaries();
+        self.calculate_monthly_summaries();
     }
 
     // --- Input Handling ---
@@ -756,16 +757,18 @@ impl App {
     fn calculate_monthly_summaries(&mut self) {
         self.monthly_summaries.clear();
         let mut years = Vec::new();
-        for tx in &self.transactions {
-            let year = tx.date.year();
-            let month = tx.date.month();
-            let summary = self.monthly_summaries.entry((year, month)).or_default();
-            match tx.transaction_type {
-                TransactionType::Income => summary.income += tx.amount,
-                TransactionType::Expense => summary.expense += tx.amount,
-            }
-            if !years.contains(&year) {
-                years.push(year);
+        for &idx in &self.filtered_indices {
+            if let Some(tx) = self.transactions.get(idx) {
+                let year = tx.date.year();
+                let month = tx.date.month();
+                let summary = self.monthly_summaries.entry((year, month)).or_default();
+                match tx.transaction_type {
+                    TransactionType::Income => summary.income += tx.amount,
+                    TransactionType::Expense => summary.expense += tx.amount,
+                }
+                if !years.contains(&year) {
+                    years.push(year);
+                }
             }
         }
         years.sort_unstable();
@@ -792,8 +795,6 @@ impl App {
 
     pub(crate) fn exit_summary_mode(&mut self) {
         self.mode = AppMode::Normal;
-        // Reset selection for main table if needed (depends on desired behavior)
-        // self.table_state.select(Some(0));
         self.status_message = None;
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -208,7 +208,8 @@ fn update(app: &mut App, key_event: KeyEvent) {
                         } else if selected_index >= len {
                             app.category_summary_table_state.select(Some(len - 1));
                         } else {
-                            app.category_summary_table_state.select(Some(selected_index));
+                            app.category_summary_table_state
+                                .select(Some(selected_index));
                         }
                     }
                 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -199,10 +199,11 @@ fn update(app: &mut App, key_event: KeyEvent) {
                             } else {
                                 app.expanded_category_summary_months.insert(*month);
                             }
+                            app.cached_visible_category_items =
+                                app.get_visible_category_summary_items();
                         }
-                        // Clamp selection to valid range
-                        let new_items = app.get_visible_category_summary_items();
-                        let len = new_items.len();
+                        // Clamp selection to valid range using cached list
+                        let len = app.cached_visible_category_items.len();
                         if len == 0 {
                             app.category_summary_table_state.select(None);
                         } else if selected_index >= len {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,4 +1,4 @@
-use crate::app::{App, AppMode};
+use crate::app::{App, AppMode, CategorySummaryItem};
 use crate::model::SortColumn;
 use crate::ui::ui;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -188,6 +188,30 @@ fn update(app: &mut App, key_event: KeyEvent) {
             }
             KeyCode::Char('[') | KeyCode::PageUp | KeyCode::Left => {
                 app.previous_category_summary_year()
+            }
+            KeyCode::Enter => {
+                let items = app.get_visible_category_summary_items();
+                if let Some(selected_index) = app.category_summary_table_state.selected() {
+                    if let Some(item) = items.get(selected_index) {
+                        if let CategorySummaryItem::Month(month, _) = item {
+                            if app.expanded_category_summary_months.contains(month) {
+                                app.expanded_category_summary_months.remove(month);
+                            } else {
+                                app.expanded_category_summary_months.insert(*month);
+                            }
+                        }
+                        // Clamp selection to valid range
+                        let new_items = app.get_visible_category_summary_items();
+                        let len = new_items.len();
+                        if len == 0 {
+                            app.category_summary_table_state.select(None);
+                        } else if selected_index >= len {
+                            app.category_summary_table_state.select(Some(len - 1));
+                        } else {
+                            app.category_summary_table_state.select(Some(selected_index));
+                        }
+                    }
+                }
             }
             _ => {}
         },

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -398,6 +398,8 @@ fn render_help_bar(f: &mut Frame, app: &App, area: Rect) {
         AppMode::CategorySummary => vec![
             Span::raw("↑↓ Nav | "),
             Span::raw("←→/[] Year | "),
+            Span::styled("Enter", Style::default().fg(Color::Magenta)),
+            Span::raw(" ▶ Expand ▼ Collapse | "),
             Span::styled("q/Esc", Style::default().fg(Color::LightRed)),
             Span::raw(" Back"),
         ],

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -578,7 +578,7 @@ fn render_summary_view(f: &mut Frame, app: &mut App, area: Rect) {
         }
     } else {
         // Add a row indicating no data if no year is selected
-        table_rows.push(Row::new(vec![Cell::from("No Data")]).height(1)); // Simple row with one cell
+        table_rows.push(Row::new(vec![Cell::from("N/A")]).height(1));
         chart_data_styled.push(Bar::default().label("N/A".into()).value(0));
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -668,35 +668,62 @@ fn render_category_summary_view(f: &mut Frame, app: &mut App, area: Rect) {
         .copied();
     let year_str = current_year.map_or_else(|| "N/A".to_string(), |y| y.to_string());
     let items = app.get_visible_category_summary_items();
-    let rows = items.iter().map(|item| {
-        match item {
-            CategorySummaryItem::Month(month, summary) => {
-                let symbol = if app.expanded_category_summary_months.contains(month) { "▼" } else { "▶" };
-                let month_cell = format!("{} {}", symbol, month_to_short_str(*month));
-                let net = summary.income - summary.expense;
-                let net_style = if net >= 0.0 { Style::default().fg(Color::LightGreen) } else { Style::default().fg(Color::LightRed) };
-                let net_str = if net >= 0.0 { format!("+{:.2}", net) } else { format!("{:.2}", net) };
-                Row::new(vec![
-                    Cell::from(month_cell),
-                    Cell::from(""), Cell::from(""),
-                    Cell::from(format!("{:.2}", summary.income)).style(Style::default().fg(Color::LightGreen)),
-                    Cell::from(format!("{:.2}", summary.expense)).style(Style::default().fg(Color::LightRed)),
-                    Cell::from(net_str).style(net_style),
-                ]).height(1).bottom_margin(0)
-            }
-            CategorySummaryItem::Subcategory(_, category, sub, summary) => {
-                let net = summary.income - summary.expense;
-                let net_style = if net >= 0.0 { Style::default().fg(Color::LightGreen) } else { Style::default().fg(Color::LightRed) };
-                let net_str = if net >= 0.0 { format!("+{:.2}", net) } else { format!("{:.2}", net) };
-                Row::new(vec![
-                    Cell::from(""),
-                    Cell::from(category.clone()),
-                    Cell::from(sub.clone()),
-                    Cell::from(format!("{:.2}", summary.income)).style(Style::default().fg(Color::LightGreen)),
-                    Cell::from(format!("{:.2}", summary.expense)).style(Style::default().fg(Color::LightRed)),
-                    Cell::from(net_str).style(net_style),
-                ]).height(1).bottom_margin(0)
-            }
+    let rows = items.iter().map(|item| match item {
+        CategorySummaryItem::Month(month, summary) => {
+            let symbol = if app.expanded_category_summary_months.contains(month) {
+                "▼"
+            } else {
+                "▶"
+            };
+            let month_cell = format!("{} {}", symbol, month_to_short_str(*month));
+            let net = summary.income - summary.expense;
+            let net_style = if net >= 0.0 {
+                Style::default().fg(Color::LightGreen)
+            } else {
+                Style::default().fg(Color::LightRed)
+            };
+            let net_str = if net >= 0.0 {
+                format!("+{:.2}", net)
+            } else {
+                format!("{:.2}", net)
+            };
+            Row::new(vec![
+                Cell::from(month_cell),
+                Cell::from(""),
+                Cell::from(""),
+                Cell::from(format!("{:.2}", summary.income))
+                    .style(Style::default().fg(Color::LightGreen)),
+                Cell::from(format!("{:.2}", summary.expense))
+                    .style(Style::default().fg(Color::LightRed)),
+                Cell::from(net_str).style(net_style),
+            ])
+            .height(1)
+            .bottom_margin(0)
+        }
+        CategorySummaryItem::Subcategory(_, category, sub, summary) => {
+            let net = summary.income - summary.expense;
+            let net_style = if net >= 0.0 {
+                Style::default().fg(Color::LightGreen)
+            } else {
+                Style::default().fg(Color::LightRed)
+            };
+            let net_str = if net >= 0.0 {
+                format!("+{:.2}", net)
+            } else {
+                format!("{:.2}", net)
+            };
+            Row::new(vec![
+                Cell::from(""),
+                Cell::from(category.clone()),
+                Cell::from(sub.clone()),
+                Cell::from(format!("{:.2}", summary.income))
+                    .style(Style::default().fg(Color::LightGreen)),
+                Cell::from(format!("{:.2}", summary.expense))
+                    .style(Style::default().fg(Color::LightRed)),
+                Cell::from(net_str).style(net_style),
+            ])
+            .height(1)
+            .bottom_margin(0)
         }
     });
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -552,38 +552,27 @@ fn render_summary_view(f: &mut Frame, app: &mut App, area: Rect) {
                 .get(&(year, month))
                 .cloned()
                 .unwrap_or_default();
-            let net = summary.income - summary.expense;
-            let net_i64 = net.round() as i64;
-            let net_style = if net >= 0.0 {
-                Style::default().fg(Color::LightGreen)
-            } else {
-                Style::default().fg(Color::LightRed)
-            };
             let month_name = month_to_short_str(month);
-            let net_str = if net >= 0.0 {
-                format!("+{:.2}", net)
-            } else {
-                format!("{:.2}", net)
-            };
-
+            let inc_cell = cell_income(summary.income);
+            let exp_cell = cell_expense(summary.expense);
+            let net_cell = cell_net(summary.income - summary.expense);
             table_rows.push(
-                Row::new(vec![
-                    Cell::from(month_name),
-                    Cell::from(format!("{:.2}", summary.income))
-                        .style(Style::default().fg(Color::LightGreen)),
-                    Cell::from(format!("{:.2}", summary.expense))
-                        .style(Style::default().fg(Color::LightRed)),
-                    Cell::from(net_str).style(net_style),
-                ])
-                .height(1)
-                .bottom_margin(0),
+                Row::new(vec![Cell::from(month_name), inc_cell, exp_cell, net_cell])
+                    .height(1)
+                    .bottom_margin(0),
             );
 
+            let net = summary.income - summary.expense;
+            let net_i64 = net.round() as i64;
             chart_data_styled.push(
                 Bar::default()
                     .label(month_name.into())
                     .value(net_i64.unsigned_abs())
-                    .style(net_style),
+                    .style(if net >= 0.0 {
+                        Style::default().fg(Color::LightGreen)
+                    } else {
+                        Style::default().fg(Color::LightRed)
+                    }),
             );
             max_abs_chart_value = max_abs_chart_value.max(net_i64.abs());
         }


### PR DESCRIPTION
This PR Addresses Issue #2 

I have added a tree style control to expand and collapse the category summary view. This makes it much cleaner and easier to manage. With lots of data entered, this page was messy so this implementation really cleans things up. 

There were then a few cleanup tasks done to remove repeated formatting, and to also now cache some values rather than re-calculate each time.

Also improved filtering mechanic to include the monthly summary view as that had been overlooked before.