### PR TITLE
Add Ctrl+F support for advanced filtering

### DIFF
--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -71,6 +71,14 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
                 Some("Enables simple filtering mode. Type to filter by any field."),
             ),
             KeyBindingInfo::new(
+                "Ctrl+F",
+                "Advanced Filter",
+                "Actions",
+                Some(
+                    "Opens the advanced filter form directly, for filtering by date range, category, type, amount, and more.",
+                ),
+            ),
+            KeyBindingInfo::new(
                 "s",
                 "Monthly Summary",
                 "Actions",

--- a/src/events/normal_mode.rs
+++ b/src/events/normal_mode.rs
@@ -26,6 +26,7 @@ pub fn handle_normal_mode(app: &mut App, key_event: KeyEvent) {
         (KeyCode::Char('a'), _) => app.start_adding(),
         (KeyCode::Char('d'), _) => app.prepare_for_delete(),
         (KeyCode::Char('e'), _) => app.start_editing(),
+        (KeyCode::Char('f'), KeyModifiers::CONTROL) => app.start_advanced_filtering(),
         (KeyCode::Char('f'), _) => app.start_filtering(),
         (KeyCode::Char('r'), _) => app.start_recurring_settings(),
         (KeyCode::Char('s'), _) => app.enter_summary_mode(),

--- a/src/events/runner.rs
+++ b/src/events/runner.rs
@@ -56,8 +56,8 @@ where
                                 || (app.mode == AppMode::Filtering && key.modifiers == KeyModifiers::CONTROL && matches!(key.code, KeyCode::Char('f') | KeyCode::Char('r')))
                                 || (app.mode == AppMode::AdvancedFiltering && key.modifiers == KeyModifiers::CONTROL && matches!(key.code, KeyCode::Char('r')))
                                 || ((app.mode == AppMode::Filtering || app.mode == AppMode::AdvancedFiltering) && key.modifiers == KeyModifiers::SHIFT && matches!(key.code, KeyCode::Char(_)))
-                                // Allow Ctrl+Up/Down for jump navigation and Ctrl+C for copy in Normal mode
-                                || (app.mode == AppMode::Normal && key.modifiers == KeyModifiers::CONTROL && matches!(key.code, KeyCode::Up | KeyCode::Down | KeyCode::Char('c')))
+                                // Allow Ctrl+Up/Down for jump navigation, Ctrl+C for copy, and Ctrl+F for advanced filter in Normal mode
+                                || (app.mode == AppMode::Normal && key.modifiers == KeyModifiers::CONTROL && matches!(key.code, KeyCode::Up | KeyCode::Down | KeyCode::Char('c') | KeyCode::Char('f')))
                                 // Allow Ctrl+H for Help Toggle
                                 || (key.modifiers == KeyModifiers::CONTROL && key.code == KeyCode::Char('h'))) =>
                 {


### PR DESCRIPTION
Make it possible to directly use control+f to get to the advanced filtering instead of having to open the f regular filter first