### PR TITLE
Remember origin when opening category catalog

### DIFF
--- a/src/app/category_manager.rs
+++ b/src/app/category_manager.rs
@@ -6,13 +6,14 @@ use crate::model::{CategoryDraft, CategoryRecord, TransactionType};
 use chrono::Duration;
 
 impl App {
-    pub(crate) fn open_category_catalog(&mut self) {
+    pub(crate) fn open_category_catalog(&mut self, origin: AppMode) {
         if let Err(err) = self.reload_categories_from_store() {
             self.set_status_message(format!("Error loading categories: {}", err), None);
             return;
         }
 
         self.mode = AppMode::CategoryCatalog;
+        self.category_catalog_origin = origin;
         self.editing_category_id = None;
         self.category_delete_id = None;
         let selection = if self.category_records.is_empty() {
@@ -30,8 +31,12 @@ impl App {
     }
 
     pub(crate) fn exit_category_catalog(&mut self) {
-        self.mode = AppMode::Settings;
+        self.mode = self.category_catalog_origin;
         self.category_delete_id = None;
+        if self.mode == AppMode::Budget {
+            // Category budgets may have changed; re-validate the month and row selection.
+            self.refresh_budget_years();
+        }
         self.clear_status_message();
     }
 

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -329,6 +329,14 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
             KeyBindingInfo::new("↑/↓", "Select Budget Row", "Navigation", None),
             KeyBindingInfo::new("←/→", "Change Month", "Navigation", None),
             KeyBindingInfo::new("Shift+←/→", "Change Year", "Navigation", None),
+            KeyBindingInfo::new(
+                "c",
+                "Manage Categories",
+                "Actions",
+                Some(
+                    "Open the category catalog to add or edit category target budgets without leaving the budget view. Esc returns here.",
+                ),
+            ),
             KeyBindingInfo::new("q/Esc", "Back to Transactions", "Actions", None),
             KeyBindingInfo::new("Ctrl+H", "Show Keybindings Help", "System", None),
         ],
@@ -435,7 +443,7 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
             KeyBindingInfo::new("a", "Add category", "Actions", None),
             KeyBindingInfo::new("e/Enter", "Edit selected category", "Actions", None),
             KeyBindingInfo::new("d", "Delete selected category", "Actions", None),
-            KeyBindingInfo::new("q/Esc", "Back to Settings", "Actions", None),
+            KeyBindingInfo::new("q/Esc", "Back to Previous View", "Actions", None),
             KeyBindingInfo::new("Ctrl+H", "Show Keybindings Help", "System", None),
         ],
         AppMode::CategoryEditor => vec![

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -345,7 +345,7 @@ impl App {
             .map(|item| item.key);
 
         match selected_key {
-            Some(SettingKey::ManageCategories) => self.open_category_catalog(),
+            Some(SettingKey::ManageCategories) => self.open_category_catalog(AppMode::Settings),
             Some(SettingKey::ImportTransactions) => {
                 self.open_transaction_io(AppMode::ImportTransactions)
             }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -121,6 +121,8 @@ pub struct App {
     pub(crate) category_edit_cursor: usize,
     pub(crate) editing_category_id: Option<i64>,
     pub(crate) category_delete_id: Option<i64>,
+    // Mode to return to when leaving the category catalog (Settings or Budget)
+    pub(crate) category_catalog_origin: AppMode,
     // Budget
     pub(crate) target_budget: Option<Decimal>,
     pub(crate) hourly_rate: Option<Decimal>,
@@ -306,6 +308,7 @@ impl App {
             category_edit_cursor: 0,
             editing_category_id: None,
             category_delete_id: None,
+            category_catalog_origin: AppMode::Settings,
             target_budget: loaded_settings.target_budget,
             hourly_rate: loaded_settings.hourly_rate,
             show_hours: loaded_settings.show_hours.unwrap_or(false),

--- a/src/events/budget_mode.rs
+++ b/src/events/budget_mode.rs
@@ -1,9 +1,10 @@
-use crate::app::state::App;
+use crate::app::state::{App, AppMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 pub fn handle_budget_mode(app: &mut App, key_event: KeyEvent) {
     match (key_event.code, key_event.modifiers) {
         (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => app.exit_budget_mode(),
+        (KeyCode::Char('c'), KeyModifiers::NONE) => app.open_category_catalog(AppMode::Budget),
         (KeyCode::Down, KeyModifiers::NONE) => app.next_budget_category(),
         (KeyCode::Up, KeyModifiers::NONE) => app.previous_budget_category(),
         (KeyCode::Right, KeyModifiers::NONE) => app.next_budget_month(),

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -212,6 +212,8 @@ pub fn render_help_bar(f: &mut Frame, app: &App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" Year | "),
+            Span::styled("c", Style::default().fg(Color::LightGreen)),
+            Span::raw(" Edit Categories | "),
             Span::styled("q/Esc", Style::default().fg(Color::LightRed)),
             Span::raw(" Back"),
         ],


### PR DESCRIPTION
Make navigating to the category catalog easier and less of a pain for quick updates to budgets.